### PR TITLE
fixed: espeak for Linux

### DIFF
--- a/accessible_output2/outputs/e_speak.py
+++ b/accessible_output2/outputs/e_speak.py
@@ -10,28 +10,25 @@ class ESpeak(Output):
 	"""
 
     name = "Linux ESpeak"
+    _ec = None
 
     def __init__(self):
         try:
             import espeak.core
+            self._ec = espeak.core
         except:
-            raise RuntimeError("Cannot find espeak.core. Please install python-espeak")
-
+            print("Cannot find espeak.core. Please install python-espeak or python3-espeak.")
 
     def is_active(self):
-        try:
-            import espeak.core
-        except:
-            return False
-        return True
+        return self._ec is not None
 
     def speak(self, text, interrupt=0):
         if interrupt:
             self.silence()
-        espeak.core.synth(text)
+        self._ec.synth(text)
 
     def silence(self):
-        espeak.core.cancel()
+        self._ec.cancel()
 
 
 output_class = ESpeak


### PR DESCRIPTION
speak() raised an exception because it couldn't find espeak.core. Added an attribute.
It prints an error instead of raising an exception when unavailable.

Tested on Debian 10 with Python 3.7 and python3-espeak.