### PR TITLE
fixed: AttributeError: module 'win32com.gen_py...' has no attribute 'CLSIDToClassMap'

### DIFF
--- a/accessible_output2/outputs/__init__.py
+++ b/accessible_output2/outputs/__init__.py
@@ -2,6 +2,25 @@ from __future__ import absolute_import
 import platform
 
 if platform.system() == "Windows":
+    from libloader import com
+    from libloader.com import load_com
+
+    def _load_com(*names):
+        try:
+            return load_com(*names)
+        except AttributeError:
+            # remove cache
+            import os
+            import sys
+            import shutil
+            for module in [m.__name__ for m in sys.modules.values()]:
+                if module.startswith("win32com.gen_py."):
+                    del sys.modules[module]
+            shutil.rmtree(os.path.join(os.environ.get('LOCALAPPDATA'), 'Temp', 'gen_py'))
+            # try again
+            return load_com(*names)
+    com.load_com = _load_com
+
     from . import nvda
     from . import jaws
     from . import sapi5


### PR DESCRIPTION
This will delete the gen_py folder (in appdata\local\Temp) and reload the cache.
Inspired by: https://gist.github.com/rdapaz/63590adb94a46039ca4a10994dff9dbe#gistcomment-2918299

Tested on Windows 10 with Python 3.7 and Python 3.8.