### PR TITLE
Linux: added Speech Dispatcher; lowered the priority of ESpeak

### DIFF
--- a/accessible_output2/outputs/__init__.py
+++ b/accessible_output2/outputs/__init__.py
@@ -35,6 +35,7 @@ if platform.system() == "Darwin":
     from . import voiceover
 
 if platform.system() == "Linux":
+    from . import speech_dispatcher
     from . import e_speak
 
 from . import auto

--- a/accessible_output2/outputs/e_speak.py
+++ b/accessible_output2/outputs/e_speak.py
@@ -10,6 +10,7 @@ class ESpeak(Output):
 	"""
 
     name = "Linux ESpeak"
+    priority = 101
     _ec = None
 
     def __init__(self):

--- a/accessible_output2/outputs/speech_dispatcher.py
+++ b/accessible_output2/outputs/speech_dispatcher.py
@@ -50,9 +50,9 @@ class SpeechDispatcher(Output):
         self._client.cancel()
 
     def close(self):
-        # Unfortunately this is never called (or too late).
-        # It should be called in a try finally
-        self._client.close() # or the program won't close
+        # With speechd < 1.10.2, this method must be called
+        # for the program to close correctly.
+        self._client.close()
 
 
 output_class = SpeechDispatcher

--- a/accessible_output2/outputs/speech_dispatcher.py
+++ b/accessible_output2/outputs/speech_dispatcher.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+from .base import Output
+
+class SpeechDispatcher(Output):
+    """Supports Speech Dispatcher on Linux
+
+    Note this requires python-speechd or python3-speechd to be installed.
+    This can be done on Debian distros by using apt-get install python3-speechd.
+    """
+
+    name = "Linux Speech Dispatcher"
+    _client = None
+    _is_speaking = False
+
+    def __init__(self):
+        global speechd
+        try:
+            import speechd
+        except:
+            print("Cannot find Speech Dispatcher. Please install python-speechd or python3-speechd.")
+        else:
+            try:
+                self._client = speechd.SSIPClient("")
+            except Exception as e:
+                print(e)
+
+    def is_active(self):
+        return self._client is not None
+
+    def is_speaking(self):
+        return self._is_speaking
+
+    def _callback(self, callback_type):
+        if callback_type == speechd.CallbackType.BEGIN:
+            self._is_speaking = True
+        elif callback_type == speechd.CallbackType.END:
+            self._is_speaking = False
+        elif callback_type == speechd.CallbackType.CANCEL:
+            self._is_speaking = False
+
+    def speak(self, text, interrupt=0):
+        if interrupt:
+            self.silence()
+        self._client.speak(text, callback=self._callback,
+                           event_types=(speechd.CallbackType.BEGIN,
+                                        speechd.CallbackType.CANCEL,
+                                        speechd.CallbackType.END))
+
+    def silence(self):
+        self._client.cancel()
+
+    def close(self):
+        # Unfortunately this is never called (or too late).
+        # It should be called in a try finally
+        self._client.close() # or the program won't close
+
+
+output_class = SpeechDispatcher


### PR DESCRIPTION
Speech Dispatcher is easier to configure than ESpeak, for example to select a specific language.

Speech Dispatcher would previously prevent the program from closing unless close() is called before.
This annoying (but not serious) issue is solved in speechd 1.10.2 :
https://github.com/brailcom/speechd/issues/405